### PR TITLE
feat: Add session reload interval option

### DIFF
--- a/control.py
+++ b/control.py
@@ -75,6 +75,7 @@ class Control:
         self.port = self.get_port()
         self.baudrate = self.get_setting("baudrate")
         self.inverted = self.get_setting("inverted").lower() == "true"
+        self.reload_interval = int(self.get_setting("session reload interval"))
 
         self.get_mapping()
 

--- a/default_mapping.txt
+++ b/default_mapping.txt
@@ -32,3 +32,6 @@ inverted:False
 
 # Set this to true if you want system sounds included in 'unmapped' if system sounds aren't assigned anywhere else.
 system in unmapped:True
+
+# Determine how often to reload the sessions for newly opened applications in seconds.
+session reload interval:1

--- a/volume_thread.py
+++ b/volume_thread.py
@@ -11,7 +11,7 @@ import utils
 from pathlib import Path
 from control import Control
 
-from PyQt5.QtCore import QThread
+from PyQt5.QtCore import QThread, QTimer
 from PyQt5.QtWidgets import QMessageBox
 
 logger = utils.get_logger()
@@ -57,6 +57,13 @@ class VolumeThread(QThread):
                 "task manager.",
             )
             raise
+
+        self.reload_timer = QTimer()
+        self.reload_timer.timeout.connect(self.control.get_sessions)
+        self.reload_timer.start(self.control.reload_interval * 1000)
+
+    def reload_sessions(self):
+        self.control.get_sessions()
 
     def run(self):
         logger.info("Entering thread loop.")

--- a/volume_thread.py
+++ b/volume_thread.py
@@ -57,10 +57,11 @@ class VolumeThread(QThread):
                 "task manager.",
             )
             raise
-
-        self.reload_timer = QTimer()
-        self.reload_timer.timeout.connect(self.control.get_sessions)
-        self.reload_timer.start(self.control.reload_interval * 1000)
+        
+        if self.control.reload_interval > 0:
+            self.reload_timer = QTimer()
+            self.reload_timer.timeout.connect(self.control.get_sessions)
+            self.reload_timer.start(self.control.reload_interval * 1000)
 
     def reload_sessions(self):
         self.control.get_sessions()


### PR DESCRIPTION
Creates a new option in `default_mapping.txt` to reload audio sessions every n_seconds (default: 1). This could already be done by clicking "Reload sessions" on the tray icon. This should fix the case where applications that are opened after launching WaVeS are not mapped to the respective sliders. Set to `0` if you want to disable this.